### PR TITLE
fix: center page title and left-align section headlines

### DIFF
--- a/_sass/_content.scss
+++ b/_sass/_content.scss
@@ -44,7 +44,7 @@
       text-align: center;
     }
 
-    .section-headline:not(.intro .section-headline) {
+    .main-content > .section-headline {
       text-align: left;
     }
 

--- a/_sass/_content.scss
+++ b/_sass/_content.scss
@@ -26,6 +26,7 @@
     margin-top: 0;
     font-size: 2rem;
     font-weight: variables.$font-weight-semi-bold;
+    text-align: left;
   }
 
   p {
@@ -37,6 +38,14 @@
 
     .section-headline {
       border-bottom: none;
+    }
+
+    .intro .section-headline {
+      text-align: center;
+    }
+
+    .section-headline:not(.intro .section-headline) {
+      text-align: left;
     }
 
     h3 {

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -42,6 +42,6 @@ body {
   .page-title {
     font-size: 54px;
     line-height: 81px;
-    text-align: end;
+    text-align: center;
   }
 }


### PR DESCRIPTION
Fixes https://github.com/tc39/tc39.github.io/issues/116 and possibly https://github.com/tc39/tc39.github.io/issues/115

This code renders exactly like the second image in this comment: https://github.com/tc39/tc39.github.io/issues/116#issuecomment-470618524