### PR TITLE
fix #406, translate fr site.json agenda and notes

### DIFF
--- a/fr/site.json
+++ b/fr/site.json
@@ -4,8 +4,8 @@
   "navigation": {
     "TC39": {
       "title": "TC39",
-      "agenda": "Meeting Agendas",
-      "notes": "Meeting Notes",
+      "agenda": "Ordres du jour",
+      "notes": "Comptes rendus",
       "sub-menu": "Basculer le sous-menu pour TC39"
     },
     "specs": {


### PR DESCRIPTION
## Summary

Closes part of #406. Provides the French translation for `site.navigation.TC39.agenda` and `site.navigation.TC39.notes` in `fr/site.json`. The previous values were the English placeholders ("Meeting Agendas" / "Meeting Notes").

| Key      | Before          | After             |
| -------- | --------------- | ----------------- |
| `agenda` | Meeting Agendas | Ordres du jour    |
| `notes`  | Meeting Notes   | Comptes rendus    |

`Ordres du jour` and `Comptes rendus` are the standard French terms for meeting agendas and meeting minutes/notes, kept short to match the navigation style of other locales (see `de/site.json`, `ru/site.json`, `ja/site.json`).

The German entry referenced in the issue (`de/site.json`) is already populated on `main` (`Tagesordnung` / `Mitschriften`), so no change is needed there.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run build` — succeeds; rendered `_site/fr/index.html` shows the new strings under the TC39 menu
- [ ] Reviewer with French fluency to double-check wording