### PR TITLE
fix: remove dead links to deleted translation_*.md files

### DIFF
--- a/de/proposals.json
+++ b/de/proposals.json
@@ -25,8 +25,8 @@
   "authors-and-champions": "Autor*innen und Meister*innen",
   "see-more": "Siehe Vorschläge in allen Phasen",
   "needs_translation": "Übersetzungen gesucht",
-  "needs_translation_url": "https://github.com/tc39/tc39.github.io/blob/main/translation_de.md",
-  "community_translations": "Diese Seite wird durch die Allgemeinheit übersetzt. Möchtest du dazu beitragen, dann wirf einen Blick auf unsere <a href=\"https://github.com/tc39/tc39.github.io/blob/main/translation_de.md\">Richtlinien</a>.",
+  "needs_translation_url": "https://github.com/tc39/tc39.github.io/blob/main/translation.md",
+  "community_translations": "Diese Seite wird durch die Allgemeinheit übersetzt. Möchtest du dazu beitragen, dann wirf einen Blick auf unsere <a href=\"https://github.com/tc39/tc39.github.io/blob/main/translation.md\">Richtlinien</a>.",
   "months": {
     "1": "Januar",
     "2": "Februar",

--- a/ja/proposals.json
+++ b/ja/proposals.json
@@ -25,8 +25,8 @@
   "authors-and-champions": "提出者、及び支持者",
   "see-more": "全ステージのプロポーザルを見る",
   "needs_translation": "翻訳が必要",
-  "needs_translation_url": "https://github.com/tc39/tc39.github.io/blob/main/translation_ja.md",
-  "community_translations": "このページはコミュニティによって翻訳されています。貢献したい場合は、<a href=\"https://github.com/tc39/tc39.github.io/blob/main/translation_ja.md\">ガイドライン</a>をお読みください。",
+  "needs_translation_url": "https://github.com/tc39/tc39.github.io/blob/main/translation.md",
+  "community_translations": "このページはコミュニティによって翻訳されています。貢献したい場合は、<a href=\"https://github.com/tc39/tc39.github.io/blob/main/translation.md\">ガイドライン</a>をお読みください。",
   "months": {
     "1": "1月",
     "2": "2月",

--- a/ru/proposals.json
+++ b/ru/proposals.json
@@ -25,8 +25,8 @@
   "authors-and-champions": "Авторы и чемпионы",
   "see-more": "Предложения на всех этапах",
   "needs_translation": "Требует перевода",
-  "needs_translation_url": "https://github.com/tc39/tc39.github.io/blob/main/translation_ru.md",
-  "community_translations": "Эта страница переведена сообществом. Если Вы хотите сделать вклад, прочитайте наши <a href=\"https://github.com/tc39/tc39.github.io/blob/main/translation_ru.md\">гайдлайны</a>.",
+  "needs_translation_url": "https://github.com/tc39/tc39.github.io/blob/main/translation.md",
+  "community_translations": "Эта страница переведена сообществом. Если Вы хотите сделать вклад, прочитайте наши <a href=\"https://github.com/tc39/tc39.github.io/blob/main/translation.md\">гайдлайны</a>.",
   "months": {
     "1": "январь",
     "2": "февраль",

--- a/translation.md
+++ b/translation.md
@@ -6,7 +6,7 @@ information about upcoming language features into their language.
 
 ## Adding a translation of a feature
 
-To translate a feature, edit the [stage 3 file](_data/en/stage3.yml) for that language. If a
+To translate a feature, edit the [stage 3 file](_data/en/stage3.json) for that language. If a
 description field is empty, that proposal needs a translation. Once you finish the translation(s),
 you can open a pull request and ping a reviewer who can ok your translation.
 
@@ -18,7 +18,7 @@ clone the [english language directory](_data/en) or any other language to start 
 Once you have created your folder, you will want to translate all text into your language. You will
 also want to copy this readme file and translate it, so others can help you.
 
-With that finished, add your language to the [language file](_data/languages.yml) of the site. You will need a reviewer to proof read your translations, and request a review from @codehag to make sure everything looks right.
+With that finished, add your language to the [language file](_data/languages.json) of the site. You will need a reviewer to proof read your translations, and request a review from @codehag to make sure everything looks right.
 
 ## Active reviewers
 
@@ -28,26 +28,18 @@ To land your changes, you can request reviews from the following active reviewer
 
 - [@codehag](https://github.com/codehag)
 
-### German transation:
+### German Translation:
 
 - ...
-
-See the [German Translation documentation](translation_de.md) for more info.
 
 ### Japanese Translation:
 
 - [@smorimoto](https://github.com/smorimoto)
 
-See the [Japanese Translation documentation](translation_ja.md) for more info.
-
 ### Russian Translation:
 
 - [@chicoxyzzy](https://github.com/chicoxyzzy)
 
-See the [Russian Translation documentation](translation_ru.md) for more info.
-
-### Traditional Chinese Translation:
+### Simplified Chinese Translation:
 
 - ...
-
-See the [Traditional Chinese Translation documentation](translation_zh-Hans.md) for more info.

--- a/uk/proposals.json
+++ b/uk/proposals.json
@@ -25,8 +25,8 @@
   "authors-and-champions": "Автори та чемпиони",
   "see-more": "Пропозиції на усіх етапах",
   "needs_translation": "Потребує перекладу",
-  "needs_translation_url": "https://github.com/tc39/tc39.github.io/blob/main/translation_uk.md",
-  "community_translations": "Ця сторінка перекладена спільнотою. Якщо Ви бажаєте зробити внесок, прочитайте наші <a href=\"https://github.com/tc39/tc39.github.io/blob/main/translation_uk.md\">довідники</a>.",
+  "needs_translation_url": "https://github.com/tc39/tc39.github.io/blob/main/translation.md",
+  "community_translations": "Ця сторінка перекладена спільнотою. Якщо Ви бажаєте зробити внесок, прочитайте наші <a href=\"https://github.com/tc39/tc39.github.io/blob/main/translation.md\">довідники</a>.",
   "months": {
     "1": "січень",
     "2": "лютий",

--- a/zh-Hans/proposals.json
+++ b/zh-Hans/proposals.json
@@ -25,8 +25,8 @@
   "authors-and-champions": "作者和推进者",
   "see-more": "查看各阶段的提案",
   "needs_translation": "需要翻译",
-  "needs_translation_url": "https://github.com/tc39/tc39.github.io/blob/main/translation_zh-Hans.md",
-  "community_translations": "这个页面的翻译是由社区贡献的。如果你也想贡献，请阅读我们的<a href=\"https://github.com/tc39/tc39.github.io/blob/main/translation_zh-Hans.md\">指引</a>。",
+  "needs_translation_url": "https://github.com/tc39/tc39.github.io/blob/main/translation.md",
+  "community_translations": "这个页面的翻译是由社区贡献的。如果你也想贡献，请阅读我们的<a href=\"https://github.com/tc39/tc39.github.io/blob/main/translation.md\">指引</a>。",
   "months": {
     "1": "1 月",
     "2": "2 月",


### PR DESCRIPTION
## Summary

Commit `ef93571` ("Remove `translation_*.md`") deleted the per-language translation docs (`translation_de.md`, `translation_ja.md`, `translation_ru.md`, `translation_uk.md`, `translation_fr.md`, `translation_zh-Hans.md`), but several references to those files were left behind and now point at 404s. This PR repoints those references at the surviving root `translation.md`, drops the now-dead "See the X Translation documentation" lines from `translation.md`, and fixes a couple of small adjacent issues spotted in the same file.

### Changes

**`translation.md`**
- Drop the four `See the [X Translation documentation](translation_X.md)` lines (all targets are deleted).
- Fix heading typo `### German transation:` → `### German Translation:`.
- Fix mislabel `### Traditional Chinese Translation:` → `### Simplified Chinese Translation:` (the section is for `zh-Hans`, which is Simplified).
- Fix two stale data-file extensions in the prose:
  - `_data/en/stage3.yml` → `_data/en/stage3.json`
  - `_data/languages.yml` → `_data/languages.json`
  (Both files are JSON in the repo; the `.yml` references are leftovers from before the Eleventy migration.)

**`{de,ja,ru,zh-Hans,uk}/proposals.json`**
For each locale, repoint two fields at the surviving doc:
- `needs_translation_url`: `…/translation_<lang>.md` → `…/translation.md`
- `community_translations`: the embedded `<a href="…/translation_<lang>.md">` link is repointed the same way.

`fr/` and `en/` already point at `translation.md`; no change needed there.

### Out of scope (deliberately not in this PR)

- Restoring per-language translation docs as separate files. If maintainers want them back, that's a separate effort and the link targets here can be flipped over again at that point.
- Untranslated strings in `de/site.json` `footer.coc`, `zh-Hans/site.json` `footer.coc`, and `fr/proposals.json` `specification` — those are real but unrelated to dead-link cleanup.

## Test plan

- [x] `grep -r 'translation_.*\.md' translation.md {de,fr,ja,ru,zh-Hans,uk,en}/proposals.json README.md` returns no matches after the change.
- [x] `npm run build` succeeds; `_site/{en,de,fr,ja,ru,zh-Hans,uk}/index.html` render normally.
- [ ] CI (lint + build) green on this PR.